### PR TITLE
configure vi bindings for tmux buffer

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -41,6 +41,14 @@ set -g status-keys vi
 # Use vi keybindings in copy and choice modes
 setw -g mode-keys vi
 
+bind-key -T edit-mode-vi Up send-keys -X history-up
+bind-key -T edit-mode-vi Down send-keys -X history-down
+unbind-key -T copy-mode-vi Space     ;   bind-key -T copy-mode-vi v send-keys -X begin-selection
+unbind-key -T copy-mode-vi Enter     ;   bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+unbind-key -T copy-mode-vi C-v       ;   bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
+unbind-key -T copy-mode-vi [         ;   bind-key -T copy-mode-vi [ send-keys -X begin-selection
+unbind-key -T copy-mode-vi ]         ;   bind-key -T copy-mode-vi ] send-keys -X copy-selection
+
 # easily toggle synchronization (mnemonic: e is for echo)
 # sends input to all panes in a given window.
 bind e setw synchronize-panes on


### PR DESCRIPTION
This commit adds the latest version of the appropriate bindings to
tmux.conf that allows highlighting and copying text from the buffer
using the vi keys.