### PR TITLE
don't overwrite register when replacing text from a paste

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -117,3 +117,22 @@ function! FlashCurrentLine()
 	sleep 300m
 	set nocul
 endfunction
+
+" Replace the register with the pasted value when using 'p' to overwrite text.
+" The vim default behavior is to fill the register with the text you just
+" overwrote.
+function! RestoreRegister()
+  let @" = s:restore_reg
+  if &clipboard == "unnamed"
+      let @* = s:restore_reg
+  endif
+  return ''
+endfunction
+
+function! s:Repl()
+    let s:restore_reg = @"
+    return "p@=RestoreRegister()\<cr>"
+endfunction
+
+" NB: this supports "rp that replaces the selection by the contents of @r
+vnoremap <silent> <expr> p <sid>Repl()


### PR DESCRIPTION
The default vim behavior is to fill the register with the
text you just overwrote when pasting. This effectively changes
it to leave the pasted text in the register, so that you can
yank + paste + paste + paste.